### PR TITLE
Fix blank space after opening bracket

### DIFF
--- a/src/Generator/Compiler/Field/FieldSetterCompiler.php
+++ b/src/Generator/Compiler/Field/FieldSetterCompiler.php
@@ -83,6 +83,8 @@ class FieldSetterCompiler extends AbstractFieldCompiler
             $validations[] = '}';
         } elseif (!empty($validatorType)) {
             $validations[] = '$this->validateInput(\'' . $this->field->getName() . '\', ' . $varname . ');';
+        } else {
+            $validations[] = '//No validator available';
         }
 
         return $validations;


### PR DESCRIPTION
Blank space in AbstractEntity setter for BlobType field raises CS errors