### PR TITLE
Remove dots in binding parameters

### DIFF
--- a/src/Query/AbstractQueryBuilder.php
+++ b/src/Query/AbstractQueryBuilder.php
@@ -78,7 +78,7 @@ abstract class AbstractQueryBuilder implements QueryBuilderInterface
     public function addBind(string $field, $value, bool $isUnique = false): string
     {
         $suffix = ($isUnique ? '_' . uniqid() : '');
-        $name   = ':' . strtolower(str_replace(['(', ')', ',', ' '], ['', '', '', '_'], $field . $suffix));
+        $name   = ':' . strtolower(str_replace(['(', ')', ',', ' ', '.'], ['', '', '', '_', '_'], $field . $suffix));
 
         if (is_bool($value)) {
             $value = (int) $value;


### PR DESCRIPTION
Binding parameters don't accept dots, which can happen when the field is prefixed with the table name to avoid ambiguity