### PR TITLE
RepositoryTrait: Fix last id when reconnection done during insert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         php-versions: [ '8.1', '8.2', '8.3' ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # To avoid "Shallow clone detected" error in SonarCloud report
 
@@ -71,7 +71,6 @@ jobs:
         run: make analyze
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v2.1.1
+        uses: SonarSource/sonarqube-scan-action@v5.1.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN:  ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN:    ${{ secrets.SONAR_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 ```
 
+## [6.0.3] - 2025-04-04
+[6.0.3]: https://github.com/eureka-framework/component-orm/compare/6.0.2...6.0.3
+### changed
+- Fix lastInsertId() usage when reconnection is done during insert query.
+
+## [6.0.2] - 2024-04-24
+[6.0.2]: https://github.com/eureka-framework/component-orm/compare/6.0.1...6.0.2
+### Changed
+- Re-add try catch type error when building joined entity that not have full data.
+
 ## [6.0.1] - 2024-04-15
 [6.0.1]: https://github.com/eureka-framework/component-orm/compare/6.0.0...6.0.1
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -43,13 +43,13 @@
   },
 
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.49.0",
+    "friendsofphp/php-cs-fixer": "^3.75.0",
     "maglnet/composer-require-checker": "^3.8||^4.7.1",
-    "phpstan/phpstan": "^1.10.59",
-    "phpstan/phpstan-phpunit": "^1.3.16",
-    "phpstan/phpstan-strict-rules": "^1.5.2",
+    "phpstan/phpstan": "^1.12.23",
+    "phpstan/phpstan-phpunit": "^1.4.2",
+    "phpstan/phpstan-strict-rules": "^1.6.2",
     "phpunit/phpcov": "^9.0.2",
-    "phpunit/phpunit": "^10.5.10",
-    "symfony/cache": "^5.4.0||^6.4.3"
+    "phpunit/phpunit": "^10.5.45",
+    "symfony/cache": "^5.4.0||^6.4.20"
   }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,9 +10,8 @@ parameters:
     - ./scripts
     - ./tests
 
-  checkGenericClassInNonGenericObjectType: false
-
   bootstrapFiles:
     - ./vendor/autoload.php
 
-  ignoreErrors: []
+  ignoreErrors:
+    - identifier: missingType.generics

--- a/src/Generator/Compiler/AbstractCompiler.php
+++ b/src/Generator/Compiler/AbstractCompiler.php
@@ -133,7 +133,7 @@ abstract class AbstractCompiler
      */
     protected function getNameForGetter(Field $field): string
     {
-        $toReplace  = array(
+        $toReplace  = [
             '/^(is_)/i',
             '/^(has_)/i',
             '/^(in_)/i', // db_prefix is empty
@@ -141,7 +141,7 @@ abstract class AbstractCompiler
             '/(_has_)/i',
             '/(_in_)/i', // db_prefix is not empty
             '/(_)/',
-        );
+        ];
         $methodName = str_replace(
             ' ',
             '',

--- a/src/Generator/Type/Factory.php
+++ b/src/Generator/Type/Factory.php
@@ -30,7 +30,7 @@ class Factory
      */
     public static function create(string $sqlType, string $sqlComment): TypeInterface
     {
-        $matches = array();
+        $matches = [];
         if (!(bool) preg_match('`^([a-z]+)\(?(\d*)\)? ?(.*)$`i', $sqlType, $matches)) {
             throw new GeneratorException('Invalid sql type');
         }

--- a/src/Traits/RepositoryTrait.php
+++ b/src/Traits/RepositoryTrait.php
@@ -125,7 +125,6 @@ trait RepositoryTrait
         }
 
         $queryBuilder = new Query\InsertBuilder($this, $entity);
-        $connection   = $this->getConnection();
 
         $statement = $this->execute(
             $queryBuilder->getQuery($onDuplicateUpdate, $onDuplicateIgnore),
@@ -141,7 +140,7 @@ trait RepositoryTrait
         }
 
         //~ If we have auto increment key (commonly, is a primary key), set value
-        $lastInsertId = (int) $connection->lastInsertId();
+        $lastInsertId = (int) $this->getConnection()->lastInsertId();
         if ($lastInsertId > 0) {
             $this->setLastId($lastInsertId);
 


### PR DESCRIPTION
When a reconnection is done during an insert query, the previous connection is closed, and access to `lastInsertId()` will always return 0

To prevent that, the connection is get just before calling `lastInsertId()`